### PR TITLE
Handle RegExp & all-around improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,22 @@
 import babelPluginSyntaxJSX from 'babel-plugin-syntax-jsx';
 import attributeVisitor from './jsx-attribute-visitor';
 
-export default function() {
+export default function({ types }) {
   return {
     pre() {
-      if (!Array.isArray(this.opts)) {
-        this.opts = ['data-test-id'];
+      this.types = types;
+
+      if (!this.opts.ids) {
+        this.opts.ids = ['data-test-id'];
+      }
+
+      if (!Array.isArray(this.opts.ids)) {
+        this.opts.ids = [this.opts.ids];
       }
     },
     inherits: babelPluginSyntaxJSX,
-    visitor: { JSXIdentifier: attributeVisitor },
+    visitor: {
+      JSXIdentifier: attributeVisitor,
+    },
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default function({ types }) {
     },
     inherits: babelPluginSyntaxJSX,
     visitor: {
-      JSXIdentifier: attributeVisitor,
+      JSXAttribute: attributeVisitor,
     },
   };
 }

--- a/src/jsx-attribute-visitor.js
+++ b/src/jsx-attribute-visitor.js
@@ -1,7 +1,15 @@
 export default (path, state) => {
+  const { types } = state;
   const { ids } = state.opts;
 
-  if (ids.includes(path.node.name)) {
-    path.parentPath.remove();
+  if (!types.isJSXIdentifier(path.node.name)) {
+    return;
+  }
+
+  const name = path.get('name');
+  const actualName = name.node.name;
+
+  if (ids.includes(actualName)) {
+    path.remove();
   }
 };

--- a/src/jsx-attribute-visitor.js
+++ b/src/jsx-attribute-visitor.js
@@ -1,7 +1,7 @@
 export default (path, state) => {
-  const attributes = state.opts;
+  const { ids } = state.opts;
 
-  if (attributes.includes(path.node.name)) {
+  if (ids.includes(path.node.name)) {
     path.parentPath.remove();
   }
 };

--- a/src/jsx-attribute-visitor.js
+++ b/src/jsx-attribute-visitor.js
@@ -1,3 +1,13 @@
+function matchesId(name, id) {
+  if (typeof id === 'string') {
+    return name === id;
+  }
+
+  // Let's be lazy and assume RegExp
+
+  return id.test(name);
+}
+
 export default (path, state) => {
   const { types } = state;
   const { ids } = state.opts;
@@ -9,7 +19,10 @@ export default (path, state) => {
   const name = path.get('name');
   const actualName = name.node.name;
 
-  if (ids.includes(actualName)) {
-    path.remove();
+  for (const id of ids) {
+    if (matchesId(actualName, id)) {
+      path.remove();
+      return;
+    }
   }
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -24,6 +24,7 @@ const customAttributeTests = [
     'Multiple custom data-test-* attributes inside nested arrays',
     { ids: ['data-test-id', 'data-test-class', 'data-test-icon', 'data-test-label', 'data-test-item'] },
   ),
+  createTest('custom_attrs/multiple', 'Multiple custom data-test-* attributes with RegExp', { ids: /^data-test-/ }),
 ];
 
 runTests('Simple components', simpleTests);

--- a/test/tests.js
+++ b/test/tests.js
@@ -12,17 +12,17 @@ const nestedTests = [
 ];
 
 const customAttributeTests = [
-  createTest('custom_attrs/single', 'Custom data-test-class attribute', ['data-test-class']),
-  createTest('custom_attrs/multiple', 'Multiple custom data-test-* attributes', [
+  createTest('custom_attrs/single', 'Custom data-test-class attribute', { ids: ['data-test-class'] }),
+  createTest('custom_attrs/multiple', 'Multiple custom data-test-* attributes', { ids: [
     'data-test-id',
     'data-test-class',
     'data-test-icon',
     'data-test-label',
-  ]),
+  ] }),
   createTest(
     'custom_attrs/nested_arrays',
     'Multiple custom data-test-* attributes inside nested arrays',
-    ['data-test-id', 'data-test-class', 'data-test-icon', 'data-test-label', 'data-test-item'],
+    { ids: ['data-test-id', 'data-test-class', 'data-test-icon', 'data-test-label', 'data-test-item'] },
   ),
 ];
 


### PR DESCRIPTION
Here's a list of changes:
- added editorconfig for higher life quality
- added ids as a named option (`ids`) instead of options themselves (this is a breaking change, warranting a major version bump)
- replaced the `JSXIdentifier` visitor with a more precise `JSXAttribute` visitor